### PR TITLE
fixed a bug when you have same server for limbo and pass-through

### DIFF
--- a/Plugin/src/main/java/xyz/kyngs/librepremium/velocity/VelocityLibrePremium.java
+++ b/Plugin/src/main/java/xyz/kyngs/librepremium/velocity/VelocityLibrePremium.java
@@ -114,6 +114,8 @@ public class VelocityLibrePremium extends AuthenticLibrePremium<Player, Register
                     )
                     .connect()
                     .whenComplete((result, throwable) -> {
+                        if(player.getCurrentServer().isEmpty()) return;
+                        if(player.getCurrentServer().get().getServerInfo().getName().equals(result.getAttemptedConnection().getServerInfo().getName())) return;
                         if (throwable != null || !result.isSuccessful())
                             player.disconnect(Component.text("Unable to connect"));
                     });


### PR DESCRIPTION
so the bug was if you set the limbo and pass-through server to same server(which u need to do when you dont have a seperate limbo server) it use to disconnect with a message "Unable to connect"

fixed it by adding a check for if the player is in same server