### PR TITLE
Add Gradle build workflow and fix encoding errors

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,0 +1,27 @@
+name: "Publish build artifact"
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+
+      - name: Allow gradlew execution
+        run: chmod +x gradlew
+
+      - name: Build
+        run: |
+          ./gradlew build
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: LibrePremium
+          path: ./Plugin/build/libs/Plugin-*.jar

--- a/Plugin/build.gradle
+++ b/Plugin/build.gradle
@@ -7,6 +7,10 @@ plugins {
 
 version '0.12.3'
 
+compileJava {
+    options.encoding('UTF-8')
+}
+
 repositories {
     mavenLocal()
     maven { url = "https://repo.aikar.co/content/groups/aikar/" }


### PR DESCRIPTION
This pull requests adds a GitHub workflow that builds the project and uploads the jar as a [build artifact](https://github.com/mdo992/LibrePremium/actions/runs/3783725392).