### PR TITLE
disable fallback feature when it's false

### DIFF
--- a/Plugin/src/main/java/xyz/kyngs/librepremium/bungeecord/BungeeCordListener.java
+++ b/Plugin/src/main/java/xyz/kyngs/librepremium/bungeecord/BungeeCordListener.java
@@ -99,16 +99,13 @@ public class BungeeCordListener extends AuthenticListeners<BungeeCordLibrePremiu
 
     @EventHandler(priority = LOW)
     public void onKick(ServerKickEvent event) {
-        var reason = plugin.getSerializer().deserialize(event.getKickReasonComponent());
-        var message = plugin.getMessages().getMessage("info-kick").replaceText("%reason%", reason);
-        var player = event.getPlayer();
-        var audience = platformHandle.getAudienceForPlayer(event.getPlayer());
+        if (plugin.getConfiguration().fallback()) {
+            var reason = plugin.getSerializer().deserialize(event.getKickReasonComponent());
+            var message = plugin.getMessages().getMessage("info-kick").replaceText("%reason%", reason);
+            var player = event.getPlayer();
+            var audience = platformHandle.getAudienceForPlayer(event.getPlayer());
 
-        if (event.getState() == ServerKickEvent.State.CONNECTED) {
-            if (!plugin.getConfiguration().fallback()) {
-                event.setKickReasonComponent(plugin.getSerializer().serialize(message));
-                event.setCancelled(false);
-            } else {
+            if (event.getState() == ServerKickEvent.State.CONNECTED) {
                 var server = plugin.chooseLobby(plugin.getDatabaseProvider().getByUUID(player.getUniqueId()), player, false);
 
                 if (server == null) {
@@ -120,9 +117,9 @@ public class BungeeCordListener extends AuthenticListeners<BungeeCordLibrePremiu
 
                     audience.sendMessage(message);
                 }
+            } else {
+                audience.sendMessage(message);
             }
-        } else {
-            audience.sendMessage(message);
         }
     }
 

--- a/Plugin/src/main/java/xyz/kyngs/librepremium/velocity/VelocityListeners.java
+++ b/Plugin/src/main/java/xyz/kyngs/librepremium/velocity/VelocityListeners.java
@@ -78,15 +78,13 @@ public class VelocityListeners extends AuthenticListeners<VelocityLibrePremium, 
 
     @Subscribe(order = PostOrder.EARLY)
     public void onKick(KickedFromServerEvent event) {
-        var reason = event.getServerKickReason().orElse(Component.text("null"));
-        var message = plugin.getMessages().getMessage("info-kick").replaceText("%reason%", reason);
-        var player = event.getPlayer();
+        if (plugin.getConfiguration().fallback()) {
+            var reason = event.getServerKickReason().orElse(Component.text("null"));
+            var message = plugin.getMessages().getMessage("info-kick").replaceText("%reason%", reason);
+            var player = event.getPlayer();
 
-        if (event.kickedDuringServerConnect()) {
-            event.setResult(KickedFromServerEvent.Notify.create(message));
-        } else {
-            if (!plugin.getConfiguration().fallback()) {
-                event.setResult(KickedFromServerEvent.DisconnectPlayer.create(message));
+            if (event.kickedDuringServerConnect()) {
+                event.setResult(KickedFromServerEvent.Notify.create(message));
             } else {
                 var server = plugin.chooseLobby(plugin.getDatabaseProvider().getByUUID(player.getUniqueId()), player, false);
 


### PR DESCRIPTION
Fixes https://github.com/kyngs/LibrePremium/issues/22

Hello! This patch makes it so that when `fallback` is `false`, LibrePremium will not touch `onKick` events at all.

Works nicely on my server and seems to be intended behaviour, is there any use case this could break?